### PR TITLE
Fixed a bug that caused the script to crush if a word's definition had no usage example(s)

### DIFF
--- a/wiktionaryparserru/parser.py
+++ b/wiktionaryparserru/parser.py
@@ -32,6 +32,8 @@ class WiktionaryParser:
             if text:
                 text = "".join(re.findall("[-◆А-яё.,! ]+", text))
                 text_split = text.split(self.SEMANTICS_SPLIT_SYMBOL)
+                if len(text_split) == 1:
+                    text_split = [text, "Отсутствует пример употребления"]
                 self.result["definitions"].append({
                     "value": text_split[0].strip(),
                     "example": text_split[1].strip()


### PR DESCRIPTION
If one definition of a word didn't have a usage example on the website, the script checked for it as an element of a list and throwed an error because it didn't find one. It was true, for example, for a word "дорога".

Now it appends a string "Отсутствует пример употребления" (en. "Lacks usage example") that is being treated as a from-dictionary-fetched example later in the script.